### PR TITLE
Fixed timer inicialization - or at least made it more portable

### DIFF
--- a/PadSwitcher64.c
+++ b/PadSwitcher64.c
@@ -310,11 +310,11 @@ uint8_t MASTERHELD;
 	//Setting up system tick clock
 	//****************************
 	
-	TCCR0A = (WGM01<<1);			// Set timer0A CTC mode
-	TCCR0B = (CS02<<1)|(CS00<<1);	// Set timer0A 1024 clock divider
+	TCCR0A = _BV(WGM01);			// Set timer0A CTC mode
+	TCCR0B = _BV(CS02) | _BV(CS00);	// Set timer0A 1024 clock divider
 	OCR0A = 19;						// set timer0A compare = 19 - should be roughly 205Hz
 	
-	TIMSK0 = OCIE0A<<1;				// Enable timer0A interrupt
+	TIMSK0 = _BV(OCIE0A);				// Enable timer0A interrupt
 
 	SetupPorts();
 	


### PR DESCRIPTION
I backported this project to atmega8, since that was what I had home, and it took me ages to figure out why it's not working: Turns out, the timer initialization was incorrect, it used bit<<1 instead of 1<<bit operations. 

Lucky for you, these were mostly interchangeable on the 88, although I think your timer divider was 256.